### PR TITLE
IBuilderFormattable

### DIFF
--- a/src/StringInterpolation/IBuilderFormattable.cs
+++ b/src/StringInterpolation/IBuilderFormattable.cs
@@ -1,0 +1,17 @@
+﻿namespace StringInterpolation;
+
+/// <summary>
+/// Implements <see cref="ISpanFormattable.TryFormat(Span{char}, out int, ReadOnlySpan{char}, IFormatProvider?)"/>
+/// by using <see cref="SpanStringBuilder"/>.
+/// </summary>
+public interface IBuilderFormattable : IDefaultSpanFormattable
+{
+    bool Format(scoped SpanStringBuilder builder, ReadOnlySpan<char> format);
+
+    bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
+    {
+        charsWritten = 0;
+        var builder = new SpanStringBuilder(destination, ref charsWritten, provider);
+        return Format(builder, format);
+    }
+}

--- a/src/StringInterpolation/SpanStringBuilder.cs
+++ b/src/StringInterpolation/SpanStringBuilder.cs
@@ -1,0 +1,118 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace StringInterpolation;
+
+/// <summary>
+/// Pair of <see cref="Span{char}"/> and ref int
+/// to write
+/// <code><![CDATA[
+/// bool TryWrite(SpanStringBuilder destination)
+/// {
+///     if (!destination.Append(a) return false;
+///     if (!destination.Append(b) return false;
+///     // ...
+///     return true;
+/// }
+/// ]]></code>
+/// instead of 
+/// <code><![CDATA[
+/// bool TryWrite(Span<char> destination, out int charsWritten)
+/// {
+///     if (destination.TryWrite(a, out var w) charsWritten += w; else return;
+///     if (destination.TryWrite(b, out w) charsWritten += w; else return;
+///     // ...
+///     return true;
+/// }
+/// ]]></code>
+/// </summary>
+/// <remarks>
+/// This internally uses <see cref="MemoryExtensions.TryWriteInterpolatedStringHandler"/>.
+/// </remarks>
+public ref struct SpanStringBuilder
+{
+    private Span<char> _destination;
+    private readonly ref int _pos;
+    private readonly IFormatProvider? _provider;
+
+    public SpanStringBuilder(Span<char> destination, ref int charsWritten) : this(destination, ref charsWritten, null) { }
+
+    public SpanStringBuilder(Span<char> destination, ref int charsWritten, IFormatProvider? provider)
+    {
+        _destination = destination;
+        _pos = ref charsWritten;
+        _provider = provider;
+    }
+
+    private Span<char> Destination => _destination[_pos..];
+
+    public bool Success => _destination != default;
+
+    private bool Fail()
+    {
+        _destination = default;
+        return false;
+    }
+
+    private bool Ok(int charsWritten)
+    {
+        _pos += charsWritten;
+        return true;
+    }
+
+    public bool Append(string value)
+    {
+        if (!Success) return false;
+        return !value.TryCopyTo(Destination) ? Fail() : Ok(value.Length);
+    }
+
+    public bool Append<T>(T value, ReadOnlySpan<char> format = default, IFormatProvider? provier = null)
+        where T : ISpanFormattable
+    {
+        if (!Success) return false;
+        return !value.TryFormat(Destination, out var w, format, provier ?? _provider) ? Fail() : Ok(w);
+    }
+
+    public bool Append([InterpolatedStringHandlerArgument("")] scoped InterpolatedStringHandler handler)
+    {
+        if (!Success) return false;
+        return !handler.TryGetResult(out var w) ? Fail() : Ok(w);
+    }
+
+    public bool Append(IFormatProvider? provider, [InterpolatedStringHandlerArgument("", nameof(provider))] scoped InterpolatedStringHandler handler)
+    {
+        if (!Success) return false;
+        return !handler.TryGetResult(out var w) ? Fail() : Ok(w);
+    }
+
+    [InterpolatedStringHandler]
+    public ref struct InterpolatedStringHandler
+    {
+        private MemoryExtensions.TryWriteInterpolatedStringHandler _inner;
+
+        public InterpolatedStringHandler(int literalLength, int formattedCount, SpanStringBuilder destination, out bool shouldAppend)
+            => _inner = new(literalLength, formattedCount, destination.Destination, destination._provider, out shouldAppend);
+
+        public InterpolatedStringHandler(int literalLength, int formattedCount, SpanStringBuilder destination, IFormatProvider? provider, out bool shouldAppend)
+            => _inner = new(literalLength, formattedCount, destination.Destination, provider ?? destination._provider, out shouldAppend);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool AppendLiteral(string value) => _inner.AppendLiteral(value);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool AppendFormatted<T>(T value) => _inner.AppendFormatted(value);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool AppendFormatted<T>(T value, string? format) => _inner.AppendFormatted(value, format);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool AppendFormatted<T>(T value, int alignment) => _inner.AppendFormatted(value, alignment);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool AppendFormatted<T>(T value, int alignment, string? format) => _inner.AppendFormatted(value, alignment, format);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool AppendFormatted(scoped ReadOnlySpan<char> value) => _inner.AppendFormatted(value);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool AppendFormatted(scoped ReadOnlySpan<char> value, int alignment = 0, string? format = null) => _inner.AppendFormatted(value, alignment, format);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool AppendFormatted(string? value) => _inner.AppendFormatted(value);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool AppendFormatted(string? value, int alignment = 0, string? format = null) => _inner.AppendFormatted(value, alignment, format);
+        internal bool TryGetResult(out int charsWritten) => default(Span<char>).TryWrite(ref _inner, out charsWritten);
+    }
+}

--- a/test/StringInterpolationTest/IBuilderFormattableTest.cs
+++ b/test/StringInterpolationTest/IBuilderFormattableTest.cs
@@ -1,0 +1,78 @@
+﻿using System.Globalization;
+
+namespace StringInterpolationTest;
+
+public class IBuilderFormattableTest
+{
+    private class Format : IBuilderFormattable
+    {
+        bool IBuilderFormattable.Format(SpanStringBuilder builder, ReadOnlySpan<char> format)
+            => builder.Append($"format:{format}");
+    }
+
+    [Fact]
+    public void WithFormat()
+    {
+        var formats = new[]
+        {
+            "x", "X4", "yyyy-MM-dd", "any string"
+        };
+
+        IFormattable a = new Format();
+
+        foreach (var f in formats)
+        {
+            var actual = a.ToString(f, CultureInfo.InvariantCulture);
+            Assert.Equal($"format:{f}", actual);
+        }
+    }
+
+    private class Provider : IBuilderFormattable
+    {
+        public bool Format(SpanStringBuilder builder, ReadOnlySpan<char> format)
+            => builder.Append($"{1.2}/{new DateOnly(2000, 1, 2)}");
+    }
+
+    [Fact]
+    public void WithProvider()
+    {
+        var providers = new[]
+        {
+            (CultureInfo.InvariantCulture, "1.2/01/02/2000"),
+            (CultureInfo.GetCultureInfo("ja-jp"), "1.2/2000/01/02"),
+            (CultureInfo.GetCultureInfo("fr-fr"), "1,2/02/01/2000"),
+        };
+
+        IFormattable a = new Provider();
+
+        foreach (var (p, expected) in providers)
+        {
+            var actual = a.ToString(null, p);
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    private class LongerThan1000 : IBuilderFormattable
+    {
+        public bool Format(SpanStringBuilder builder, ReadOnlySpan<char> format)
+        {
+            int i = 0;
+            for (; i < 100; i++)
+            {
+                if (!builder.Append($"0123456789abcdef")) return false;
+            }
+            return true;
+        }
+    }
+
+    [Fact]
+    public void WriteLongerThan1000Chars()
+    {
+        var expected = string.Join("", Enumerable.Range(0, 100).Select(_ => "0123456789abcdef"));
+
+        IFormattable a = new LongerThan1000();
+        var actual = a.ToString(null, null);
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/test/StringInterpolationTest/IDefaultSpanFormattableTest.cs
+++ b/test/StringInterpolationTest/IDefaultSpanFormattableTest.cs
@@ -14,7 +14,7 @@ public class IDefaultSpanFormattableTest
     }
 
     [Fact]
-    public void FormatFormat()
+    public void WithFormat()
     {
         var formats = new[]
         {
@@ -42,7 +42,7 @@ public class IDefaultSpanFormattableTest
     }
 
     [Fact]
-    public void FormatProvider()
+    public void WithProvider()
     {
         var providers = new[]
         {
@@ -86,7 +86,7 @@ public class IDefaultSpanFormattableTest
     }
 
     [Fact]
-    public void FormatLongerThan1000Chars()
+    public void WriteLongerThan1000Chars()
     {
         var expected = $"format:abcd/provider:{CultureInfo.InvariantCulture.GetType().Name}/"
             + string.Join("", Enumerable.Range(0, 100).Select(_ => "0123456789"));

--- a/test/StringInterpolationTest/SpanStringBuilderTest.cs
+++ b/test/StringInterpolationTest/SpanStringBuilderTest.cs
@@ -1,0 +1,35 @@
+﻿namespace StringInterpolationTest;
+
+public class SpanStringBuilderTest
+{
+    [Fact]
+    public void Append()
+    {
+        var destination = (stackalloc char[10]);
+        int charsWritten = 0;
+        var builder = new SpanStringBuilder(destination, ref charsWritten);
+
+        Assert.True(builder.Append("a"));
+        Assert.True(builder.Success);
+        Assert.Equal(1, charsWritten);
+        Assert.Equal("a", destination[..charsWritten].ToString());
+
+        Assert.True(builder.Append(12));
+        Assert.True(builder.Success);
+        Assert.Equal(3, charsWritten);
+        Assert.Equal("a12", destination[..charsWritten].ToString());
+
+        Assert.True(builder.Append($"a{1}b"));
+        Assert.True(builder.Success);
+        Assert.Equal(6, charsWritten);
+        Assert.Equal("a12a1b", destination[..charsWritten].ToString());
+
+        Assert.True(builder.Append("abc"));
+        Assert.True(builder.Success);
+        Assert.Equal(9, charsWritten);
+        Assert.Equal("a12a1babc", destination[..charsWritten].ToString());
+
+        Assert.False(builder.Append("ab"));
+        Assert.False(builder.Success);
+    }
+}


### PR DESCRIPTION
To write

```cs
bool TryWrite(SpanStringBuilder destination)
{
    if (!destination.Append(a) return false;
    if (!destination.Append(b) return false;
    // ...
    return true;
}
```

instead of 

```cs
bool TryWrite(Span<char> destination, out int charsWritten)
{
    if (destination.TryWrite(a, out var w) charsWritten += w; else return;
    if (destination.TryWrite(b, out w) charsWritten += w; else return;
    // ...
    return true;
}
```
