### PR TITLE
SortableDateTime

### DIFF
--- a/src/StringInterpolation/SortableDateTime.cs
+++ b/src/StringInterpolation/SortableDateTime.cs
@@ -1,0 +1,29 @@
+﻿using System.Globalization;
+
+namespace StringInterpolation;
+
+public static class SortableDateTime
+{
+    /// <summary>
+    /// Overrides DateTimeFormat to be sortable, yyyy-MM-dd HH:mm:ss.
+    /// </summary>
+    public static CultureInfo ToSortable(this CultureInfo culture)
+    {
+        var c = (CultureInfo)culture.Clone();
+        c.DateTimeFormat.LongDatePattern = "yyyy'-'MM'-'dd";
+        c.DateTimeFormat.LongTimePattern = "HH':'mm':'ss";
+        c.DateTimeFormat.MonthDayPattern = "MM'-'dd";
+        c.DateTimeFormat.YearMonthPattern = "yyyy'-'MM";
+        c.DateTimeFormat.ShortDatePattern = "yyyy'-'MM'-'dd";
+        c.DateTimeFormat.ShortTimePattern = "HH':'mm':'ss";
+        return c;
+    }
+
+    /// <summary>
+    /// <see cref="CultureInfo.InvariantCulture"/> with <see cref="ToSortable(CultureInfo)"/>.
+    /// </summary>
+    /// <remarks>
+    /// It is insane that the invariant one uses MM/dd/yyyy.
+    /// </remarks>
+    public static readonly CultureInfo InvariantCulture = CultureInfo.InvariantCulture.ToSortable();
+}

--- a/test/StringInterpolationTest/SortableDateTimeTest.cs
+++ b/test/StringInterpolationTest/SortableDateTimeTest.cs
@@ -1,0 +1,49 @@
+﻿using System.Globalization;
+
+namespace StringInterpolationTest;
+
+public class SortableDateTimeTest
+{
+    [Fact]
+    public void ToSortable()
+    {
+        var cultures = new[]
+        {
+            (CultureInfo.InvariantCulture, "1.2", "¤1.00"),
+            (CultureInfo.GetCultureInfo("ja-jp"), "1.2", "￥1"),
+            (CultureInfo.GetCultureInfo("fr-fr"), "1,2", "1,00 €"),
+        };
+
+        var date = new DateOnly(2000, 1, 2);
+        var time = new TimeOnly(3, 4, 5);
+        var dt = date.ToDateTime(time, DateTimeKind.Unspecified);
+        var dto = new DateTimeOffset(dt, TimeSpan.FromHours(9));
+
+        var current = Thread.CurrentThread.CurrentCulture;
+
+        foreach (var (c, expected1_2, expectedCurrency) in cultures)
+        {
+            Thread.CurrentThread.CurrentCulture = c.ToSortable();
+
+            // Depends on culture.
+            Assert.Equal(expected1_2, $"{1.2}");
+            Assert.Equal(expectedCurrency, $"{1:C}");
+
+            // Always uses sortable format for DateTime.
+            Assert.Equal("2000-01-02", $"{dt:d}");
+            Assert.Equal("2000-01-02", $"{dt:D}");
+            Assert.Equal("2000-01-02 03:04:05", $"{dt:f}");
+            Assert.Equal("2000-01-02 03:04:05", $"{dt:F}");
+            Assert.Equal("2000-01", $"{dt:y}");
+            Assert.Equal("01-02", $"{dt:m}");
+            Assert.Equal("03:04:05", $"{dt:t}");
+
+            Assert.Equal("2000-01-02", $"{date}");
+            Assert.Equal("03:04:05", $"{time}");
+            Assert.Equal("2000-01-02 03:04:05 +09:00", $"{dto}");
+        }
+
+
+        Thread.CurrentThread.CurrentCulture = current;
+    }
+}


### PR DESCRIPTION
Overrides DateTimeFormat to be sortable, yyyy-MM-dd HH:mm:ss. It is insane that the invariant one uses MM/dd/yyyy.

## Open Question

I am still struggling with naming this class/methods.
