### PR TITLE
Join

### DIFF
--- a/StringInterpolation.sln
+++ b/StringInterpolation.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{EAD34800-5
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StringInterpolationTest", "test\StringInterpolationTest\StringInterpolationTest.csproj", "{44F83AC0-D2BF-42B1-B12B-0AE25BA22B49}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StringInterpolationBenchmark", "test\StringInterpolationBenchmark\StringInterpolationBenchmark.csproj", "{A6F7A65D-E15F-4121-AF66-ACE1319BAD80}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{44F83AC0-D2BF-42B1-B12B-0AE25BA22B49}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{44F83AC0-D2BF-42B1-B12B-0AE25BA22B49}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{44F83AC0-D2BF-42B1-B12B-0AE25BA22B49}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A6F7A65D-E15F-4121-AF66-ACE1319BAD80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6F7A65D-E15F-4121-AF66-ACE1319BAD80}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6F7A65D-E15F-4121-AF66-ACE1319BAD80}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6F7A65D-E15F-4121-AF66-ACE1319BAD80}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -40,5 +46,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{CF8DCD1B-BD6A-4336-80B1-B5C4D807BDE0} = {19AEC829-4EEA-4185-943F-65B28B09F9B0}
 		{44F83AC0-D2BF-42B1-B12B-0AE25BA22B49} = {EAD34800-5121-4054-8287-82BDF675497B}
+		{A6F7A65D-E15F-4121-AF66-ACE1319BAD80} = {EAD34800-5121-4054-8287-82BDF675497B}
 	EndGlobalSection
 EndGlobal

--- a/src/StringInterpolation/Format.Join.cs
+++ b/src/StringInterpolation/Format.Join.cs
@@ -44,4 +44,9 @@ public static partial class Format
             return true;
         }
     }
+
+    /// <summary>
+    /// Concatenates strings without temprary string allocation.
+    /// </summary>
+    public static JoinFormattable Concat(IEnumerable<string> values) => new("", values);
 }

--- a/src/StringInterpolation/Format.Join.cs
+++ b/src/StringInterpolation/Format.Join.cs
@@ -1,0 +1,47 @@
+﻿namespace StringInterpolation;
+
+public static partial class Format
+{
+    /// <summary>
+    /// Joins strings without temprary string allocation.
+    /// </summary>
+    /// <remarks>
+    /// Comparing to <see cref="string.Join(string?, IEnumerable{string?})"/>,
+    /// this method is better in terms of memory allocation but not always better in performance.
+    /// In general, this is slower than string.Join when the values is too long.
+    /// If you want Join long sequence, you should use enough initialBuffer explicitly.
+    /// e.g.
+    ///
+    /// <code><![CDATA[
+    /// var buffer = ArrayPool<char>.Shared.Rent(enoughSize);
+    /// var s = string.Create(null, buffer,
+    ///     $"{Format.Join(", ", LongSequence())}");
+    /// ArrayPool<char>.Shared.Return(buffer);
+    /// return s;
+    /// ]]></code>
+    /// </remarks>
+    public static JoinFormattable Join(string separator, IEnumerable<string> values) => new(separator, values);
+
+    /// <summary>
+    /// <see cref="Join(string, IEnumerable{string})"/>
+    /// </summary>
+    public readonly struct JoinFormattable : IBuilderFormattable
+    {
+        public readonly string Separator;
+        public readonly IEnumerable<string> Values;
+        public JoinFormattable(string separator, IEnumerable<string> values) => (Separator, Values) = (separator, values);
+
+        public bool Format(scoped SpanStringBuilder builder, ReadOnlySpan<char> format)
+        {
+            bool part = false;
+            foreach (var value in Values)
+            {
+                if (!part) part = true;
+                else if (!builder.Append(Separator)) return false;
+
+                if (!builder.Append(value)) return false;
+            }
+            return true;
+        }
+    }
+}

--- a/src/StringInterpolation/Format.JoinT.cs
+++ b/src/StringInterpolation/Format.JoinT.cs
@@ -1,0 +1,38 @@
+﻿namespace StringInterpolation;
+
+public static partial class Format
+{
+    /// <summary>
+    /// Joins <see cref="ISpanFormattable"/>s without temprary string allocation.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Join(string, IEnumerable{string})"/>
+    /// </remarks>
+    public static JoinFormattable<T> Join<T>(string separator, IEnumerable<T> values)
+        where T : ISpanFormattable
+        => new(separator, values);
+
+    /// <summary>
+    /// <see cref="Join{T}(string, IEnumerable{T})"/>
+    /// </summary>
+    public readonly struct JoinFormattable<T> : IBuilderFormattable
+        where T : ISpanFormattable
+    {
+        public readonly string Separator;
+        public readonly IEnumerable<T> Values;
+        public JoinFormattable(string separator, IEnumerable<T> values) => (Separator, Values) = (separator, values);
+
+        public bool Format(scoped SpanStringBuilder builder, ReadOnlySpan<char> format)
+        {
+            bool part = false;
+            foreach (var value in Values)
+            {
+                if (!part) part = true;
+                else if (!builder.Append(Separator)) return false;
+
+                if (!builder.Append(value, format)) return false;
+            }
+            return true;
+        }
+    }
+}

--- a/src/StringInterpolation/Format.JoinT.cs
+++ b/src/StringInterpolation/Format.JoinT.cs
@@ -35,4 +35,11 @@ public static partial class Format
             return true;
         }
     }
+
+    /// <summary>
+    /// Concatenates <see cref="ISpanFormattable"/>s without temprary string allocation.
+    /// </summary>
+    public static JoinFormattable<T> Concat<T>(IEnumerable<T> values)
+        where T : ISpanFormattable
+        => new("", values);
 }

--- a/test/StringInterpolationBenchmark/JoinBenchmark.cs
+++ b/test/StringInterpolationBenchmark/JoinBenchmark.cs
@@ -1,0 +1,52 @@
+﻿using BenchmarkDotNet.Attributes;
+using StringInterpolation;
+using System.Buffers;
+
+namespace StringInterpolationBenchmark;
+
+[MemoryDiagnoser]
+public class JoinBenchmark
+{
+    private static IEnumerable<int> Fibonacci()
+    {
+        int current = 1, next = 1;
+
+        while (true)
+        {
+            yield return current;
+            next = current + (current = next);
+        }
+    }
+
+    [Params(10, 100, 1000/*, 10_000*/)]
+    public int N { get; set; }
+
+    // baseline
+    [Benchmark]
+    public string StringJoin() => $"new[] {{ {string.Join(", ", Fibonacci().Take(N))} }}";
+
+    [Benchmark]
+    public string StringJoinWithBuffer()
+    {
+        var buffer = ArrayPool<char>.Shared.Rent(10 * N);
+        var s = string.Create(null, buffer,
+            $"new[] {{ {string.Join(", ", Fibonacci().Take(N))} }}");
+        ArrayPool<char>.Shared.Return(buffer);
+        return s;
+    }
+
+    // less allocated but much slower
+    [Benchmark]
+    public string FormatJoin() => $"new[] {{ {Format.Join(", ", Fibonacci().Take(N))} }}";
+
+    // least allocated and faster
+    [Benchmark]
+    public string FormatJoinWithBuffer()
+    {
+        var buffer = ArrayPool<char>.Shared.Rent(10 * N);
+        var s = string.Create(null, buffer,
+            $"new[] {{ {Format.Join(", ", Fibonacci().Take(N))} }}");
+        ArrayPool<char>.Shared.Return(buffer);
+        return s;
+    }
+}

--- a/test/StringInterpolationBenchmark/Program.cs
+++ b/test/StringInterpolationBenchmark/Program.cs
@@ -1,0 +1,4 @@
+﻿using BenchmarkDotNet.Running;
+using StringInterpolationBenchmark;
+
+BenchmarkRunner.Run<JoinBenchmark>();

--- a/test/StringInterpolationBenchmark/StringInterpolationBenchmark.csproj
+++ b/test/StringInterpolationBenchmark/StringInterpolationBenchmark.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\StringInterpolation\StringInterpolation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.3" />
+  </ItemGroup>
+
+</Project>

--- a/test/StringInterpolationTest/JoinTest.cs
+++ b/test/StringInterpolationTest/JoinTest.cs
@@ -1,4 +1,6 @@
-﻿namespace StringInterpolationTest;
+﻿using System.Globalization;
+
+namespace StringInterpolationTest;
 
 public class JoinTest
 {
@@ -16,5 +18,70 @@ public class JoinTest
         Assert.Equal(
             string.Join(" / ", Enumerable.Repeat("123456789abcdefghijk", 100)),
             $"{Format.Join(" / ", Enumerable.Repeat("123456789abcdefghijk", 100))}");
+    }
+
+    [Fact]
+    public void JoinT()
+    {
+        Assert.Equal(
+            "1,12,123,1234",
+            $"{Format.Join(",", new[] { 1, 12, 123, 1234 })}");
+
+        Assert.Equal(
+            "1000, 1000000, 1000000000, 1000000000000",
+            $"{Format.Join(", ", new long[] { 1000, 1000000, 1000000000, 1000000000000 })}");
+
+        Assert.Equal(
+            string.Join(" / ", Enumerable.Repeat(123456789, 100)),
+            $"{Format.Join(" / ", Enumerable.Repeat(123456789, 100))}");
+    }
+
+    [Fact]
+    public void JoinWithCulture()
+    {
+        var jp = CultureInfo.GetCultureInfo("ja-jp");
+        var fr = CultureInfo.GetCultureInfo("fr-fr");
+
+        var nums = new[] { 1.2, 1.5, 1.7 };
+        var dates = new[] { new DateOnly(2000, 1, 2), new DateOnly(2020, 12, 31) };
+
+        Assert.Equal(
+            "1.2/1.5/1.7",
+            string.Create(jp, $"{Format.Join("/", nums)}"));
+
+        Assert.Equal(
+            "1,2/1,5/1,7",
+            string.Create(fr, $"{Format.Join("/", nums)}"));
+
+        Assert.Equal(
+            "2000/01/02, 2020/12/31",
+            string.Create(jp, $"{Format.Join(", ", dates)}"));
+
+        Assert.Equal(
+            "02/01/2000, 31/12/2020",
+            string.Create(fr, $"{Format.Join(", ", dates)}"));
+    }
+
+    [Fact]
+    public void JoinWithFormat()
+    {
+        var nums = new[] { 5, 10, 15, 20 };
+        var dates = new[] { new DateOnly(2000, 1, 2), new DateOnly(2020, 12, 31) };
+
+        Assert.Equal(
+            "5/10/15/20",
+            $"{Format.Join("/", nums):d}");
+
+        Assert.Equal(
+            "5/a/f/14",
+            $"{Format.Join("/", nums):x}");
+
+        Assert.Equal(
+            "05/0A/0F/14",
+            $"{Format.Join("/", nums):X2}");
+
+        Assert.Equal(
+            "01-2000, 12-2020",
+            $"{Format.Join(", ", dates):MM-yyyy}");
     }
 }

--- a/test/StringInterpolationTest/JoinTest.cs
+++ b/test/StringInterpolationTest/JoinTest.cs
@@ -1,0 +1,20 @@
+﻿namespace StringInterpolationTest;
+
+public class JoinTest
+{
+    [Fact]
+    public void Join()
+    {
+        Assert.Equal(
+            "a,b,c,d",
+            $"{Format.Join(",", new[] { "a", "b", "c", "d" })}");
+
+        Assert.Equal(
+            "abc, def, ghi, jkl",
+            $"{Format.Join(", ", new[] { "abc", "def", "ghi", "jkl" })}");
+
+        Assert.Equal(
+            string.Join(" / ", Enumerable.Repeat("123456789abcdefghijk", 100)),
+            $"{Format.Join(" / ", Enumerable.Repeat("123456789abcdefghijk", 100))}");
+    }
+}

--- a/test/StringInterpolationTest/JoinTest.cs
+++ b/test/StringInterpolationTest/JoinTest.cs
@@ -21,6 +21,22 @@ public class JoinTest
     }
 
     [Fact]
+    public void Concat()
+    {
+        Assert.Equal(
+            "abcd",
+            $"{Format.Concat(new[] { "a", "b", "c", "d" })}");
+
+        Assert.Equal(
+            "abcdefghijkl",
+            $"{Format.Concat(new[] { "abc", "def", "ghi", "jkl" })}");
+
+        Assert.Equal(
+            string.Concat(Enumerable.Repeat("123456789abcdefghijk", 100)),
+            $"{Format.Concat(Enumerable.Repeat("123456789abcdefghijk", 100))}");
+    }
+
+    [Fact]
     public void JoinT()
     {
         Assert.Equal(
@@ -34,6 +50,22 @@ public class JoinTest
         Assert.Equal(
             string.Join(" / ", Enumerable.Repeat(123456789, 100)),
             $"{Format.Join(" / ", Enumerable.Repeat(123456789, 100))}");
+    }
+
+    [Fact]
+    public void ConcatT()
+    {
+        Assert.Equal(
+            "1121231234",
+            $"{Format.Concat(new[] { 1, 12, 123, 1234 })}");
+
+        Assert.Equal(
+            "1000100000010000000001000000000000",
+            $"{Format.Concat(new long[] { 1000, 1000000, 1000000000, 1000000000000 })}");
+
+        Assert.Equal(
+            string.Concat(Enumerable.Repeat(123456789, 100)),
+            $"{Format.Concat(Enumerable.Repeat(123456789, 100))}");
     }
 
     [Fact]


### PR DESCRIPTION
Compared with string.Join

pros.

* Less heap allocation
* You can specify formats: `$"{Format.Join("/", nums):X2}"`

cons.

* Slower in general
  * Avoidable if you use explicit initialBuffer

Benchmark results:

|               Method |    N |        Mean |     Error |    StdDev |   Gen0 |   Gen1 | Allocated |
|--------------------- |----- |------------:|----------:|----------:|-------:|-------:|----------:|
|           StringJoin |   10 |    181.9 ns |   2.76 ns |   2.58 ns | 0.0324 |      - |     424 B |
| StringJoinWithBuffer |   10 |    192.7 ns |   1.76 ns |   1.65 ns | 0.0324 |      - |     424 B |
|           FormatJoin |   10 |    178.1 ns |   1.10 ns |   1.03 ns | 0.0184 |      - |     240 B |
| FormatJoinWithBuffer |   10 |    177.7 ns |   2.56 ns |   2.14 ns | 0.0184 |      - |     240 B |
|           StringJoin |  100 |  2,432.4 ns |  19.86 ns |  17.60 ns | 0.6142 | 0.0076 |    8032 B |
| StringJoinWithBuffer |  100 |  2,506.2 ns |  25.60 ns |  21.37 ns | 0.6142 | 0.0038 |    8032 B |
|           FormatJoin |  100 |  3,740.6 ns |  11.89 ns |  11.12 ns | 0.1793 |      - |    2384 B |
| FormatJoinWithBuffer |  100 |  1,917.1 ns |  10.68 ns |   9.99 ns | 0.1602 |      - |    2128 B |
|           StringJoin | 1000 | 26,588.7 ns | 108.30 ns |  84.55 ns | 7.0801 | 1.1597 |   92848 B |
| StringJoinWithBuffer | 1000 | 27,358.5 ns | 291.18 ns | 272.37 ns | 7.0801 | 0.5798 |   92848 B |
|           FormatJoin | 1000 | 49,690.5 ns | 781.65 ns | 731.16 ns | 1.8311 | 0.1221 |   24576 B |
| FormatJoinWithBuffer | 1000 | 20,695.1 ns | 158.78 ns | 140.76 ns | 1.8005 | 0.1221 |   23808 B |
