### PR TITLE
CultureSpedificStringBuilder

### DIFF
--- a/src/StringInterpolation/CultureSpedificStringBuilder.cs
+++ b/src/StringInterpolation/CultureSpedificStringBuilder.cs
@@ -1,0 +1,97 @@
+﻿using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace StringInterpolation;
+
+public static partial class StringBuilderExtensions
+{
+    /// <summary>
+    /// Associates <paramref name="builder"/> with <paramref name="provider"/>.
+    /// </summary>
+    /// <remarks>
+    /// CultureInfo should be explicitly specified.
+    ///
+    /// see:
+    /// https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+    /// https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md
+    /// https://learn.microsoft.com/en-us/dotnet/standard/base-types/string-comparison-net-5-plus
+    /// </remarks>
+    public static CultureSpedificStringBuilder With(this StringBuilder builder, IFormatProvider provider) => new(builder, provider);
+
+    /// <summary>
+    /// <see cref="With(StringBuilder, IFormatProvider)"/> with <see cref="CultureInfo.InvariantCulture"/>.
+    /// </summary>
+    public static CultureSpedificStringBuilder Invariant(this StringBuilder builder) => new(builder, CultureInfo.InvariantCulture);
+}
+
+/// <summary>
+/// Always specifies explicit <see cref="Provider"/> on appending values to <see cref="StringBuilder"/>.
+/// </summary>
+public class CultureSpedificStringBuilder
+{
+    public StringBuilder Builder { get; }
+    public IFormatProvider Provider { get; }
+
+    public CultureSpedificStringBuilder(StringBuilder builder, IFormatProvider provider)
+    {
+        Builder = builder;
+        Provider = provider;
+    }
+
+    public override string ToString() => Builder.ToString();
+
+    public CultureSpedificStringBuilder Append(string value)
+    {
+        Builder.Append(value);
+        return this;
+    }
+
+    public CultureSpedificStringBuilder Append(ReadOnlySpan<char> value)
+    {
+        Builder.Append(value);
+        return this;
+    }
+
+    public CultureSpedificStringBuilder Append<T>(T value, IFormatProvider? provier = null)
+        where T : ISpanFormattable
+    {
+        Builder.Append(provier ?? Provider, $"{value}");
+        return this;
+    }
+
+    public CultureSpedificStringBuilder Append(
+        [InterpolatedStringHandlerArgument("")]
+        ref InterpolatedStringHandler handler
+        ) => this;
+
+    [InterpolatedStringHandler]
+    public ref struct InterpolatedStringHandler
+    {
+        private StringBuilder.AppendInterpolatedStringHandler _inner;
+
+        public InterpolatedStringHandler(int literalLength, int formattedCount, CultureSpedificStringBuilder destination)
+            => _inner = new(literalLength, formattedCount, destination.Builder, destination.Provider);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendLiteral(string value) => _inner.AppendLiteral(value);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendFormatted<T>(T value) => _inner.AppendFormatted(value);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendFormatted<T>(T value, string? format) => _inner.AppendFormatted(value, format);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendFormatted<T>(T value, int alignment) => _inner.AppendFormatted(value, alignment);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendFormatted<T>(T value, int alignment, string? format) => _inner.AppendFormatted(value, alignment, format);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendFormatted(scoped ReadOnlySpan<char> value) => _inner.AppendFormatted(value);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendFormatted(scoped ReadOnlySpan<char> value, int alignment = 0, string? format = null) => _inner.AppendFormatted(value, alignment, format);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendFormatted(string? value) => _inner.AppendFormatted(value);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _inner.AppendFormatted(value, alignment, format);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _inner.AppendFormatted(value, alignment, format);
+    }
+}

--- a/test/StringInterpolationTest/CultureSpedificStringBuilderTest.cs
+++ b/test/StringInterpolationTest/CultureSpedificStringBuilderTest.cs
@@ -1,0 +1,53 @@
+﻿using System.Globalization;
+using System.Text;
+
+namespace StringInterpolationTest;
+
+public class CultureSpedificStringBuilderTest
+{
+    [Fact]
+    public void Culture()
+    {
+        Assert.Equal(
+            "1,2",
+            new StringBuilder()
+                .With(CultureInfo.GetCultureInfo("fr-fr"))
+                .Append(1.2)
+                .ToString());
+
+        Assert.Equal(
+            "1,2 1,00 € 02/01/2000",
+            new StringBuilder()
+                .With(CultureInfo.GetCultureInfo("fr-fr"))
+                .Append($"{1.2} {1:C} {new DateOnly(2000, 1, 2)}")
+                .ToString());
+
+        Assert.Equal(
+            "1.2",
+            new StringBuilder()
+                .With(CultureInfo.GetCultureInfo("ja-jp"))
+                .Append(1.2)
+                .ToString());
+
+        Assert.Equal(
+            "1.2 ￥1 2000/01/02",
+            new StringBuilder()
+                .With(CultureInfo.GetCultureInfo("ja-jp"))
+                .Append($"{1.2} {1:C} {new DateOnly(2000, 1, 2)}")
+                .ToString());
+
+        Assert.Equal(
+            "1.2",
+            new StringBuilder()
+                .Invariant()
+                .Append(1.2)
+                .ToString());
+
+        Assert.Equal(
+            "1.2 ¤1.00 01/02/2000",
+            new StringBuilder()
+                .Invariant()
+                .Append($"{1.2} {1:C} {new DateOnly(2000, 1, 2)}")
+                .ToString());
+    }
+}


### PR DESCRIPTION
CultureInfo should be explicitly specified.

see:
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1304
https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md
https://learn.microsoft.com/en-us/dotnet/standard/base-types/string-comparison-net-5-plus
