### PR TITLE
Extract interface from CultureSpedificStringBuilder

### DIFF
--- a/src/StringInterpolation/CultureSpedificStringBuilder.cs
+++ b/src/StringInterpolation/CultureSpedificStringBuilder.cs
@@ -30,10 +30,16 @@ public static partial class StringBuilderExtensions
     public static CultureSpedificStringBuilder SortableInvariant(this StringBuilder builder) => new(builder, SortableDateTime.InvariantCulture);
 }
 
+public interface IBuilderProviderPair
+{
+    StringBuilder Builder { get; }
+    IFormatProvider Provider { get; }
+}
+
 /// <summary>
 /// Always specifies explicit <see cref="Provider"/> on appending values to <see cref="StringBuilder"/>.
 /// </summary>
-public class CultureSpedificStringBuilder
+public class CultureSpedificStringBuilder : IBuilderProviderPair
 {
     public StringBuilder Builder { get; }
     public IFormatProvider Provider { get; }
@@ -75,7 +81,7 @@ public class CultureSpedificStringBuilder
     {
         private StringBuilder.AppendInterpolatedStringHandler _inner;
 
-        public InterpolatedStringHandler(int literalLength, int formattedCount, CultureSpedificStringBuilder destination)
+        public InterpolatedStringHandler(int literalLength, int formattedCount, IBuilderProviderPair destination)
             => _inner = new(literalLength, formattedCount, destination.Builder, destination.Provider);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/StringInterpolationTest/CultureSpedificStringBuilderTest.cs
+++ b/test/StringInterpolationTest/CultureSpedificStringBuilderTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace StringInterpolationTest;
@@ -67,5 +68,29 @@ public class CultureSpedificStringBuilderTest
                 .SortableInvariant()
                 .Append($"{1.2} {1:C} {new DateOnly(2000, 1, 2)}")
                 .ToString());
+    }
+
+    [Fact]
+    public void Interface()
+    {
+        Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+
+        Assert.Equal(
+            "1,2",
+            new X()
+                .Append($"{1.2}")
+                .ToString());
+    }
+
+    class X : IBuilderProviderPair
+    {
+        public StringBuilder Builder { get; } = new();
+        public IFormatProvider Provider { get; } = CultureInfo.GetCultureInfo("fr-fr");
+
+        public X Append(
+            [InterpolatedStringHandlerArgument("")]
+            ref CultureSpedificStringBuilder.InterpolatedStringHandler handler) => this;
+
+        public override string ToString() => Builder.ToString();
     }
 }


### PR DESCRIPTION
Now, CultureSpedificStringBuilder can be diverted in arbitrary classes.
